### PR TITLE
Enable UserGemfile for custom gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER errbit
 RUN git clone https://github.com/errbit/errbit.git /opt/errbit/app
 
 WORKDIR /opt/errbit/app
-RUN /opt/ruby/bin/bundle install --deployment
+RUN /opt/ruby/bin/bundle install --path vendor/bundle
 RUN PATH=/opt/ruby/bin:$PATH bundle exec rake assets:precompile
 
 ADD launch.bash /opt/launch.bash

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ setting the ```PORT``` environment variable like this:
 docker run -d --name errbit --link mongodb:mongodb -e PORT=5000 -p 5000:5000 turley/errbit
 ```
 
+### Custom Gems
+
+You can add gems such as issue tracker plugins by creating a UserGemfile:
+
+```
+docker create --name errbit --link mongodb:mongodb -p 3000:3000 turley/errbit
+docker cp UserGemfile errbit:/opt/errbit/app/UserGemfile
+docker start errbit
+```
+
 ## Upgrade
 
 To upgrade you need to replace the errbit container and upgrade the database.

--- a/launch.bash
+++ b/launch.bash
@@ -6,6 +6,13 @@ export PATH=/opt/ruby/bin:$PATH
 if [ -z "$SECRET_TOKEN" -a ! -f "config/initializers/__secret_token.rb" ]; then
   echo "Errbit::Application.config.secret_token = '$(bundle exec rake secret)'" > config/initializers/__secret_token.rb
 fi
+
+# We already bundle install in the dockerfile
+# bundle install again to ensure UserGemfile is loaded before any action
+if [ -f "UserGemfile" ]; then
+  bundle install --path vendor/bundle
+fi
+
 if [ "$1" == "web" ]; then
   bundle exec puma -C ./config/puma.default.rb
 elif [ "$1" == "seed" ]; then


### PR DESCRIPTION
This prevents the Gemfile from being locked down and calls `bundle install` again if a UserGemfile is used. I needed this in order to add the redmine_errbit_plugin.